### PR TITLE
Spartan camera Date Time Original fix

### DIFF
--- a/src/cameras.py
+++ b/src/cameras.py
@@ -169,24 +169,44 @@ class SpartanCamera(BaseCamera):
     Implements Spartan camera emails.
     """
     name = 'Spartan'
+    DATETIME_RE = re.compile(r'^(\d{4})-(\d{2})-(\d{2}) (\d{2}:\d{2}:\d{2})')
 
     def get_exif(self, image):
         return helpers.get_exif(image)
-    
+
     def evaluate_make(self):
         return 'hcowireless' in self.email['From']
-    
+
     def get_additional_metadata(self):
-        subject_line = self.email['subject']
+        subject_line = self.email['subject'] or ''
         print(f'subject line: {subject_line}')
-        camera_id = subject_line.split('-')[-1]
-        return {'camera_id': camera_id} if camera_id else {}
+        parts = subject_line.split(' - ')
+        camera_id = parts[-1].strip() if len(parts) > 1 else None
+        dt_match = self.DATETIME_RE.match(subject_line)
+        date_time_original = (
+            f'{dt_match.group(1)}:{dt_match.group(2)}:{dt_match.group(3)} '
+            f'{dt_match.group(4)}'
+            if dt_match else None)
+        ret = {}
+        if camera_id:
+            ret['camera_id'] = camera_id
+        if date_time_original:
+            ret['date_time_original'] = date_time_original
+        return ret
 
     def get_images(self):
         return helpers.save_attached_images(self.email)
 
     def prep_new_tags(self, existing_exif=None):
-        return {'SerialNumber': self.metadata.get('camera_id')}
+        existing_exif = [{}] if not existing_exif else existing_exif
+        ret = {}
+        camera_id = self.metadata.get('camera_id')
+        if camera_id:
+            ret['SerialNumber'] = camera_id
+        date_time_original = self.metadata.get('date_time_original')
+        if date_time_original and not existing_exif[0].get('EXIF:DateTimeOriginal'):
+            ret['DateTimeOriginal'] = date_time_original
+        return ret
 
 
 class SwiftCamera(BaseCamera):

--- a/tests/examples.py
+++ b/tests/examples.py
@@ -82,6 +82,16 @@ with open(
         _swift_fh.read(), policy=email.policy.default)
 
 
+'''
+Spartan
+'''
+SPARTAN_EMAIL = email.message.EmailMessage()
+SPARTAN_EMAIL['From'] = 'alert@hcowireless.com'
+SPARTAN_EMAIL['Subject'] = '2026-07-30 13:43:18 - RedTankSRT'
+
+SPARTAN_EMAIL_NO_DATETIME = email.message.EmailMessage()
+SPARTAN_EMAIL_NO_DATETIME['From'] = 'alert@hcowireless.com'
+SPARTAN_EMAIL_NO_DATETIME['Subject'] = '- RedTankSRT'
 
 
 def create_chunked_image_response():

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -134,3 +134,37 @@ class TestSwiftCamera(TestCase):
         save_attached_images.assert_called_once_with(examples.SWIFT_EMAIL)
 
 
+class TestSpartanCamera(TestCase):
+
+    def test_evaluate_make(self):
+        camera = cameras.SpartanCamera(examples.SPARTAN_EMAIL)
+        self.assertTrue(camera.evaluate_make())
+        camera = cameras.SpartanCamera(examples.OTHER_EMAIL)
+        self.assertFalse(camera.evaluate_make())
+
+    def test_parse_metadata(self):
+        camera = cameras.SpartanCamera(examples.SPARTAN_EMAIL)
+        self.assertEqual(camera.get_additional_metadata(), {
+            'camera_id': 'RedTankSRT',
+            'date_time_original': '2026:07:30 13:43:18'})
+
+    def test_format_exifdata_with_datetime_fallback(self):
+        camera = cameras.SpartanCamera(examples.SPARTAN_EMAIL)
+        self.assertEqual(
+            camera.prep_new_tags(existing_exif=None), {
+                'SerialNumber': 'RedTankSRT',
+                'DateTimeOriginal': '2026:07:30 13:43:18'})
+
+    def test_format_exifdata_existing_datetime_preserved(self):
+        camera = cameras.SpartanCamera(examples.SPARTAN_EMAIL)
+        existing = [{'EXIF:DateTimeOriginal': '2026:01:01 00:00:00'}]
+        result = camera.prep_new_tags(existing_exif=existing)
+        self.assertNotIn('DateTimeOriginal', result)
+        self.assertEqual(result.get('SerialNumber'), 'RedTankSRT')
+
+    def test_format_exifdata_no_subject_datetime(self):
+        camera = cameras.SpartanCamera(examples.SPARTAN_EMAIL_NO_DATETIME)
+        result = camera.prep_new_tags(existing_exif=None)
+        self.assertNotIn('DateTimeOriginal', result)
+
+


### PR DESCRIPTION
Some images from Spartan cameras evidently lack `DateTimeOriginal` tags in their EXIF data, so this PR uses the timestamp in the subject line as a fallback. 

**NOTE:** this also introduces a bug fix that will be a breaking change. Previously we had been splitting out the serial numbers by looking for a "-" in the subject line string and assuming that everything after the hyphen was the serial number. However, if a _user's serial number includes a hyphen_, we'll only be using the string of characters following the last hyphen as the serial number. So for subject line like: `"2026-07-30 07:40:58 - GL-pond"`, only the `"pond"` part is extracted as the serial number.

This PR fixes that by taking everything after " - " (with spaces) in the subject line as the serial numbers. The active Spartan cameras in prod have been updated accordingly.